### PR TITLE
Prompt history scrollback + bug fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,8 @@
 #### Bugs:
 - scrolling of textarea not working, not increasing in size unless paste happens. this is a because the expansion is triggered due to counting newlines in the box, and if typing, or pasting text with no newlines, expansion wont happen
 - cursor is broken since migration to bubbletea V2 (tell it to blink, seperate from the focus cmd now)
+- cursor should be placed at end of line when placeholder shows up
+- textarea is not foused on startup on tmux
 
 #### UI:
 - move horizontal padding out into the view functions. dont pad in md renderer. add left gutter for copy?

--- a/TODO.md
+++ b/TODO.md
@@ -3,24 +3,23 @@
 
 #### Bugs:
 - scrolling of textarea not working, not increasing in size unless paste happens. this is a because the expansion is triggered due to counting newlines in the box, and if typing, or pasting text with no newlines, expansion wont happen
-- cursor is broken since migration to bubbletea V2
+- cursor is broken since migration to bubbletea V2 (tell it to blink, seperate from the focus cmd now)
 
 #### UI:
-- during streaming, only render current prompt and response for better UX. upon stream completion, render entire history and reposition where user was at the moment the stream completed. if a scrollup happens at vp.YOffset==0, render entire history, reposition to scroll pos
 - move horizontal padding out into the view functions. dont pad in md renderer. add left gutter for copy?
-- when textarea empty, keypad up/vim up cycles up in history. when at last char in textarea, keypad down/vim down cycles down in history if any
+- add popup command menu when holding ctrl
+- insert newline into textarea once V2 is used
+- add prompt editor (double clicking prompt), invoke $EDITOR on prompt buf. would be useful for adding code comment context after a paste
+- during streaming, only render current prompt and response for better UX. upon stream completion, render entire history and reposition where user was at the moment the stream completed. if a scrollup happens at vp.YOffset==0, render entire history, reposition to scroll pos
 - mark prompt lines in new selection gutter on the left side of screen
 - impl discoloring/stop blinking when focus is lost
 - impl some consistent scrolling or positioning when user clicks enter to submit a prompt
-- add popup command menu when holding ctrl
 - add messages for history cleared etc.
-- insert newline into textarea once V2 is used
 - File uploads by drag/dropping into terminal
 
 #### Rendering:
 - Hyperlinks/citations, at least for claude models, as terminal hyperlinks: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 - Fix Markdown H2s
-- preallocate currentResponse builder using maxTokens * ANSI multiplier
 
 #### Model Support:
 - impl usage cost caluclation

--- a/tui/chat/entry.go
+++ b/tui/chat/entry.go
@@ -15,7 +15,7 @@ type ChatEntry struct {
 }
 
 // formattedPrompt creates a prompt string formatted with margin and padding.
-// It tries to emulate iMessage, right-justifying the prompt and adding a left margin
+// It tries to emulate iMessage by adding a left margin
 func (c *ChatEntry) formattedPrompt(marginText string, promptStyle lipgloss.Style, maxWidth int) string {
 	fullPromptStyle := promptStyle.
 		PaddingLeft(maxWidth - lipgloss.Width(c.prompt) - styles.H_PADDING*2). // replace lg.W with textWidth if bugged

--- a/tui/chat/model.go
+++ b/tui/chat/model.go
@@ -11,7 +11,7 @@ import (
 type ChatModel struct {
 	history    []ChatEntry
 	stream     *ResponseStream
-	scrollBack Buffer
+	Scrollback *Traverser
 	TotalCost  float64
 
 	renderedHistory      bytes.Buffer // stores accumulated chat history rendered in markdown and color for a specific width
@@ -33,15 +33,13 @@ func (s *ResponseStream) Len() int {
 }
 
 func NewChatModel(glamourStyle string) *ChatModel {
-	history := make([]ChatEntry, 0, 10)
-	return &ChatModel{
-		stream:  &ResponseStream{},
-		history: history,
-		scrollBack: Buffer{
-			history: &history,
-		},
+	model := ChatModel{
+		stream:   &ResponseStream{},
+		history:  make([]ChatEntry, 0, 10),
 		Markdown: NewMarkdownRenderer(glamourStyle),
 	}
+	model.Scrollback = NewTraverser(&model.history)
+	return &model
 }
 
 func (c *ChatModel) numPrompts() int {

--- a/tui/chat/model.go
+++ b/tui/chat/model.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"bytes"
+	"errors"
 
 	"github.com/charmbracelet/lipgloss/v2"
 	styles "github.com/gregriff/ducky/tui/styles"
@@ -182,4 +183,13 @@ func (c *ChatModel) Clear() {
 
 func (c *ChatModel) HistoryLen() int {
 	return len(c.history)
+}
+
+// GetPrompt returns the prompt at the given index
+func (c *ChatModel) GetPrompt(idx int) (string, error) {
+	historyLen := c.HistoryLen()
+	if 0 > idx || idx > historyLen {
+		return "", errors.New("Invalid index")
+	}
+	return c.history[idx].prompt, nil
 }

--- a/tui/chat/model.go
+++ b/tui/chat/model.go
@@ -95,8 +95,8 @@ func (c *ChatModel) AddResponse() {
 // Render returns a string of the entire chat history in markdown, wrapped to a certain width. If the vpWidth hasn't changed since the
 // last call to this func, the pre-rendered chat history will be reused and the ResponseStream will be appended to it
 func (c *ChatModel) Render(vpWidth int) (content string) {
-	numPrompts, numResponses := c.numPrompts(), c.numResponses()
-	if numPrompts == 0 && numResponses == 0 {
+	numChatEntries := max(c.numPrompts(), c.numResponses())
+	if numChatEntries == 0 {
 		return ""
 	}
 	responseWidth := int(float64(vpWidth) * styles.WIDTH_PROPORTION_RESPONSE)
@@ -107,7 +107,7 @@ func (c *ChatModel) Render(vpWidth int) (content string) {
 		c.numChatsRendered = c.renderChatHistory(0, vpWidth, responseWidth, false)
 	} else {
 		// when we have a new prompt or response, append to renderedHistory the latest rendered prompt/response
-		if c.numChatsRendered < max(numPrompts, numResponses) {
+		if c.numChatsRendered < numChatEntries {
 			c.numChatsRendered = c.renderChatHistory(c.numChatsRendered, vpWidth, responseWidth, false)
 		} else {
 			if !c.renderedLastResponse {

--- a/tui/chat/scrollback.go
+++ b/tui/chat/scrollback.go
@@ -1,0 +1,75 @@
+package tui
+
+import (
+	"fmt"
+)
+
+// scrollback.Buffer provides functionality that enables the TUI textarea to cycle through the prompt history
+// by performing read-only operations on ChatModel.history
+type Buffer struct {
+	history    *[]ChatEntry
+	currentIdx int // corresponds to the prompt currently visible in the prompt textarea
+	userInput  string
+}
+
+// Len returns the length of the chat history, +1, since we need to take into account the prompt
+// the user is currently typing in these calculations
+func (b *Buffer) Len() int {
+	return len(*b.history) + 1
+}
+
+// GetPrompt returns the prompt at the given index
+func (b *Buffer) GetPrompt(idx int) string {
+	historyLen := len(*b.history)
+	if 0 > idx || idx >= historyLen {
+		panic(fmt.Sprintf("GetPrompt err...\n%v#", b))
+	}
+	return (*b.history)[idx].prompt
+}
+
+func (b *Buffer) NextPrompt() string {
+	// if we're not searching
+	if b.currentIdx == -1 {
+		return ""
+	}
+
+	// if the user is viewing the last prompt in the list, we need to show them what they typed before cycling
+	if b.currentIdx == len(*b.history)-1 {
+		// this means they're no longer cycling through the history, so denote that with -1
+		b.currentIdx = -1
+		return b.userInput
+	}
+
+	if b.currentIdx > len(*b.history)-1 {
+		panic(fmt.Sprintf("This shouldn't happen...\n%v#", b))
+	}
+
+	prompt := b.GetPrompt(b.currentIdx + 1)
+	b.currentIdx += 1
+	return prompt
+}
+
+// TODO: use visibleText as param to know if to save edited text as userInput?
+func (b *Buffer) PrevPrompt(visibleText string) string {
+	if b.currentIdx == -1 {
+		b.userInput = visibleText // save user input to restore later
+
+		mostRecentPromptIdx := len(*b.history) - 1
+		prompt := b.GetPrompt(mostRecentPromptIdx)
+		b.currentIdx = mostRecentPromptIdx
+		return prompt
+	}
+
+	// if user is viewing the first prompt in the history and are still trying to go up
+	if b.currentIdx == 0 {
+		return ""
+	}
+
+	if b.currentIdx < 0 {
+		panic(fmt.Sprintf("This shouldn't happen...\n%v#", b))
+	}
+
+	prompt := b.GetPrompt(b.currentIdx - 1)
+	b.currentIdx -= 1
+	return prompt
+}

--- a/tui/chat/scrollback.go
+++ b/tui/chat/scrollback.go
@@ -4,72 +4,120 @@ import (
 	"fmt"
 )
 
-// scrollback.Buffer provides functionality that enables the TUI textarea to cycle through the prompt history
-// by performing read-only operations on ChatModel.history
-type Buffer struct {
-	history    *[]ChatEntry
-	currentIdx int // corresponds to the prompt currently visible in the prompt textarea
-	userInput  string
+// scrollback.Traverser provides functionality that enables the TUI textarea to cycle through the prompt history
+// by performing read-only operations on ChatModel.history. It's a bi-directional iterator over the prompt history
+// that keeps track of modifications made to any prompt in the history, until the user submits the prompt.
+// It attemps to emulate Python's REPL history traversal
+type Traverser struct {
+	history       *[]ChatEntry
+	currentIdx    int            // corresponds to the prompt currently visible in the prompt textarea
+	userInput     string         // what the user typed in the textarea before traversing the history
+	editedPrompts map[int]string // stores idx:prompt mappings for prompts that the user modifies when traversing history
 }
 
-// Len returns the length of the chat history, +1, since we need to take into account the prompt
-// the user is currently typing in these calculations
-func (b *Buffer) Len() int {
-	return len(*b.history) + 1
-}
-
-// GetPrompt returns the prompt at the given index
-func (b *Buffer) GetPrompt(idx int) string {
-	historyLen := len(*b.history)
-	if 0 > idx || idx >= historyLen {
-		panic(fmt.Sprintf("GetPrompt err...\n%v#", b))
+func NewTraverser(historyPtr *[]ChatEntry) *Traverser {
+	return &Traverser{
+		history:       historyPtr,
+		currentIdx:    -1,
+		editedPrompts: make(map[int]string),
 	}
-	return (*b.history)[idx].prompt
 }
 
-func (b *Buffer) NextPrompt() string {
+// getPrompt returns the prompt at the given index
+func (t *Traverser) getPrompt(idx int) string {
+	historyLen := len(*t.history)
+	if 0 > idx || idx >= historyLen {
+		panic(fmt.Sprintf("GetPrompt err...\n%#v\nHistoryLen:%d", t, len(*t.history)))
+	}
+	return (*t.history)[idx].prompt
+}
+
+// NextPrompt should not be called if the prompt history is empty
+func (t *Traverser) NextPrompt(visibleText string) (prompt string, found bool) {
+	historyLen := len(*t.history)
+	if historyLen == 0 {
+		return "", false
+	}
+
 	// if we're not searching
-	if b.currentIdx == -1 {
-		return ""
+	if t.currentIdx == -1 {
+		return "", false
+	}
+
+	if t.currentIdx > historyLen-1 {
+		panic(fmt.Sprintf("This shouldn't happen...\n%#v\nHistoryLen:%d", t, len(*t.history)))
+	}
+
+	if visibleText != t.getPrompt(t.currentIdx) {
+		t.editedPrompts[t.currentIdx] = visibleText
 	}
 
 	// if the user is viewing the last prompt in the list, we need to show them what they typed before cycling
-	if b.currentIdx == len(*b.history)-1 {
+	if t.currentIdx == historyLen-1 {
 		// this means they're no longer cycling through the history, so denote that with -1
-		b.currentIdx = -1
-		return b.userInput
+		t.currentIdx = -1
+		return t.userInput, true
 	}
 
-	if b.currentIdx > len(*b.history)-1 {
-		panic(fmt.Sprintf("This shouldn't happen...\n%v#", b))
+	nextPrompt := t.getPrompt(t.currentIdx + 1)
+	t.currentIdx += 1
+
+	if modifiedPrompt, exists := t.editedPrompts[t.currentIdx]; exists {
+		return modifiedPrompt, true
 	}
 
-	prompt := b.GetPrompt(b.currentIdx + 1)
-	b.currentIdx += 1
-	return prompt
+	return nextPrompt, true
 }
 
-// TODO: use visibleText as param to know if to save edited text as userInput?
-func (b *Buffer) PrevPrompt(visibleText string) string {
-	if b.currentIdx == -1 {
-		b.userInput = visibleText // save user input to restore later
+// PrevPrompt should not be called if the prompt history is empty
+func (t *Traverser) PrevPrompt(visibleText string) (prompt string, found bool) {
+	historyLen := len(*t.history)
+	if historyLen == 0 {
+		return "", false
+	}
 
-		mostRecentPromptIdx := len(*b.history) - 1
-		prompt := b.GetPrompt(mostRecentPromptIdx)
-		b.currentIdx = mostRecentPromptIdx
-		return prompt
+	if t.currentIdx == -1 {
+		t.userInput = visibleText // save user input to restore later
+		mostRecentPromptIdx := historyLen - 1
+
+		var prompt string
+		if editedPrompt, exists := t.editedPrompts[mostRecentPromptIdx]; exists {
+			prompt = editedPrompt
+		} else {
+			prompt = t.getPrompt(mostRecentPromptIdx)
+		}
+		t.currentIdx = mostRecentPromptIdx
+		return prompt, true
 	}
 
 	// if user is viewing the first prompt in the history and are still trying to go up
-	if b.currentIdx == 0 {
-		return ""
+	if t.currentIdx == 0 {
+		return "", false
 	}
 
-	if b.currentIdx < 0 {
-		panic(fmt.Sprintf("This shouldn't happen...\n%v#", b))
+	if t.currentIdx < 0 {
+		panic(fmt.Sprintf("This shouldn't happen...\n%#v\nHistoryLen:%d", t, len(*t.history)))
 	}
 
-	prompt := b.GetPrompt(b.currentIdx - 1)
-	b.currentIdx -= 1
-	return prompt
+	// if user has modified the prompt on their screen since they traversed to it, then save their
+	// modifications for the rest of their traversal
+	if visibleText != t.getPrompt(t.currentIdx) {
+		t.editedPrompts[t.currentIdx] = visibleText
+	}
+
+	prevPrompt := t.getPrompt(t.currentIdx - 1)
+	t.currentIdx -= 1
+
+	if modifiedPrompt, exists := t.editedPrompts[t.currentIdx]; exists {
+		return modifiedPrompt, true
+	}
+
+	return prevPrompt, true
+}
+
+// Reset should be called whenever the user submits a prompt to the model
+func (t *Traverser) Reset() {
+	t.currentIdx = -1
+	t.userInput = ""
+	clear(t.editedPrompts)
 }

--- a/tui/chat/scrollback.go
+++ b/tui/chat/scrollback.go
@@ -34,6 +34,7 @@ func (t *Traverser) getPrompt(idx int) string {
 
 // NextPrompt should not be called if the prompt history is empty
 func (t *Traverser) NextPrompt(visibleText string) (prompt string, found bool) {
+	// log.Printf("\nNEXT CALLED: %d\n", t.currentIdx)
 	historyLen := len(*t.history)
 	if historyLen == 0 {
 		return "", false
@@ -56,6 +57,7 @@ func (t *Traverser) NextPrompt(visibleText string) (prompt string, found bool) {
 	if t.currentIdx == historyLen-1 {
 		// this means they're no longer cycling through the history, so denote that with -1
 		t.currentIdx = -1
+		// log.Printf("\n\nNEXT CALLED AND USER SHOULD SEE THEIR TAIL:\nuserInput: %s", t.userInput)
 		return t.userInput, true
 	}
 
@@ -71,6 +73,7 @@ func (t *Traverser) NextPrompt(visibleText string) (prompt string, found bool) {
 
 // PrevPrompt should not be called if the prompt history is empty
 func (t *Traverser) PrevPrompt(visibleText string) (prompt string, found bool) {
+	// log.Printf("\nPREV CALLED: %d\n", t.currentIdx)
 	historyLen := len(*t.history)
 	if historyLen == 0 {
 		return "", false
@@ -79,6 +82,7 @@ func (t *Traverser) PrevPrompt(visibleText string) (prompt string, found bool) {
 	if t.currentIdx == -1 {
 		t.userInput = visibleText // save user input to restore later
 		mostRecentPromptIdx := historyLen - 1
+		// log.Printf("\n\nUSER GOING BACK FROM TAIL. \nmostRecentPromptIdx: %d\nvisibleText: %s", mostRecentPromptIdx, visibleText)
 
 		var prompt string
 		if editedPrompt, exists := t.editedPrompts[mostRecentPromptIdx]; exists {

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -2,7 +2,6 @@ package tui
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
@@ -159,17 +158,25 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if li.RowOffset != li.Height-1 || li.ColumnOffset != li.Width-1 {
 				break
 			}
+			cursorOnFirstRow := li.RowOffset == 0
+			cursorOnLastRow := li.RowOffset == li.Height-1
+			// if cursorOnFirstRow {
+			// 	break // do
+			// } else if cursorOnLastRow {
+			// 	break // do
+			// } else { // cursor is somewhere in the middle of the text (row-wise)
+			// 	break
+			// }
 
-			log.Println("USER IS AT LAST POS OF LAST LINE")
+			// cursor is somewhere in the middle of the text (row-wise)
+			if !cursorOnFirstRow && !cursorOnLastRow {
+				break
+			}
 
 			m.numPrompts = m.chat.HistoryLen()
 			if m.numPrompts == 0 {
 				return m, nil
 			}
-
-			// TODO: prob going to need a stack.
-			// when the user goes up in history, then edits the text area, contents should be pushed onto the stack,
-			// so that when they press up again, they see the last prompt, instead of the one above the one they selected and edited
 
 			// if keyString == "up" {
 

--- a/tui/tui.go
+++ b/tui/tui.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"strings"
 
@@ -49,6 +50,10 @@ type TUIModel struct {
 	headerBuilder strings.Builder
 	lastWidth          int
 	forceHeaderRefresh bool
+
+	// prompt history textarea scroller
+	numPrompts,
+	curPromptIndex int
 }
 
 // Bubbletea messages
@@ -145,6 +150,30 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// 		if numLines > normal, set height to min(numLines, maxHeight)
 				// 		else set height to normal
 			}
+		case "up", "down":
+			li := m.textarea.LineInfo()
+			// log.Printf("%#v", li)
+
+			// if user is not at the last column of the last line in the textarea,
+			// let normal cursor actions take place
+			if li.RowOffset != li.Height-1 || li.ColumnOffset != li.Width-1 {
+				break
+			}
+
+			log.Println("USER IS AT LAST POS OF LAST LINE")
+
+			m.numPrompts = m.chat.HistoryLen()
+			if m.numPrompts == 0 {
+				return m, nil
+			}
+
+			// TODO: prob going to need a stack.
+			// when the user goes up in history, then edits the text area, contents should be pushed onto the stack,
+			// so that when they press up again, they see the last prompt, instead of the one above the one they selected and edited
+
+			// if keyString == "up" {
+
+			// }
 		}
 
 		// TODO: impl cancel response WITH CONTEXTS


### PR DESCRIPTION
- implement prompt history scrollback similar to Python's REPL. plays nicely with scroll wheel logic
- fix bugs with scroll wheel inputs
- improve automatic resizing of prompt textarea
- add ability to scroll prompts when typing normally. before this only after pasting text you could scroll